### PR TITLE
Attach MessageAttachments to a reponse as a dictionary

### DIFF
--- a/phial/wrappers.py
+++ b/phial/wrappers.py
@@ -1,4 +1,4 @@
-from typing import Dict, Pattern, IO, Optional, List
+from typing import Dict, Pattern, IO, Optional, List, Union
 
 
 class Message():
@@ -158,9 +158,10 @@ class Response():
                           will put the text response in a thread
         reation(str): A valid slack emoji name. NOTE: will only work when
                       original_ts is populated
-        attachments(List[MessageAttachments]): A list of MessageAttachment
-                                              objects to be attached to the
-                                              message
+        attachments(Union[List[MessageAttachment],
+                          List[Dict[str, Dict[str, str]]]]):
+                          A list of MessageAttachment objects to be attached
+                          to the message
 
     Examples:
         The following would send a message to a slack channel when executed ::
@@ -190,7 +191,12 @@ class Response():
                  channel: str,
                  text: Optional[str] = None,
                  original_ts: Optional[str] = None,
-                 attachments: Optional[List[MessageAttachment]] = None,
+                 attachments: Union[List[MessageAttachment],
+                                    List[Dict[str,
+                                         Union[str, Union[str,
+                                                          Dict[str,
+                                                               str]]]]],
+                                    None] = None,
                  reaction: Optional[str] = None) -> None:
         self.channel = channel
         self.text = text

--- a/phial/wrappers.py
+++ b/phial/wrappers.py
@@ -193,8 +193,8 @@ class Response():
                  channel: str,
                  text: Optional[str] = None,
                  original_ts: Optional[str] = None,
-                 attachments: Union[List[MessageAttachment],
-                                    List[MessageAttachmentJson], None] = None,
+                 attachments: Optional[Union[List[MessageAttachment],
+                                       List[MessageAttachmentJson]]] = None,
                  reaction: Optional[str] = None) -> None:
         self.channel = channel
         self.text = text

--- a/phial/wrappers.py
+++ b/phial/wrappers.py
@@ -1,5 +1,7 @@
 from typing import Dict, Pattern, IO, Optional, List, Union
 
+MessageAttachmentJson = Dict[str, Union[str, Union[str, Dict[str, str]]]]
+
 
 class Message():
     '''
@@ -192,11 +194,7 @@ class Response():
                  text: Optional[str] = None,
                  original_ts: Optional[str] = None,
                  attachments: Union[List[MessageAttachment],
-                                    List[Dict[str,
-                                         Union[str, Union[str,
-                                                          Dict[str,
-                                                               str]]]]],
-                                    None] = None,
+                                    List[MessageAttachmentJson], None] = None,
                  reaction: Optional[str] = None) -> None:
         self.channel = channel
         self.text = text

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -433,6 +433,79 @@ class TestSendMessageWithMessageAttachments(TestPhialBot):
                 text=None)
 
 
+class TestSendMessageWithMessageAttachmentsDictionary(TestPhialBot):
+    '''Test phial's send_message function with message attachments
+       passed in as a dictionary'''
+
+    def test_send_message(self):
+        self.bot.slack_client = MagicMock()
+        message = Response(channel="channel_id",
+                           attachments=[{
+                               "fallback": "fallback",
+                               "author_name": "John Doe",
+                               "author_link": "https://example.com/author",
+                               "author_icon": "https://example.com/author.jpg",
+                               "color": "#36a64f",
+                               "title": "Title",
+                               "title_link": "https://example.com",
+                               "image_url": "https://example.com/image.jpg",
+                               "text": "Go to Example Website",
+                               "footer": "Footer text",
+                               "footer_icon": "https://example.com/footer.jpg",
+                               "thumb_url": "https://example.com/thumb.jpg",
+                               "fields": [
+                                   {
+                                       "title": "Established",
+                                       "value": "2008",
+                                       "short": False
+                                   },
+                                   {
+                                       "title": "Users",
+                                       "value": "27 Million",
+                                       "short": True
+                                   }
+                               ]
+                           }])
+        self.bot.send_message(message)
+
+        attachments = """
+        [
+            {
+                "fallback":"fallback",
+                "author_name":"John Doe",
+                "author_link":"https://example.com/author",
+                "author_icon":"https://example.com/author.jpg",
+                "color":"#36a64f",
+                "title":"Title",
+                "title_link":"https://example.com",
+                "image_url":"https://example.com/image.jpg",
+                "text":"Go to Example Website",
+                "footer":"Footer text",
+                "footer_icon":"https://example.com/footer.jpg",
+                "thumb_url":"https://example.com/thumb.jpg",
+                "fields":[
+                    {
+                        "title":"Established",
+                        "value":"2008",
+                        "short":false
+                    },
+                    {
+                        "title":"Users",
+                        "value":"27 Million",
+                        "short":true
+                    }
+                ]
+            }
+        ]
+"""
+        self.bot.slack_client.api_call.assert_called_with(
+                'chat.postMessage',
+                channel='channel_id',
+                as_user=True,
+                attachments=json.dumps(json.loads(attachments)),
+                text=None)
+
+
 class TestSendReaction(TestPhialBot):
     '''Test phial's send_message function'''
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -468,7 +468,7 @@ class TestSendMessageWithMessageAttachmentsDictionary(TestPhialBot):
                            }])
         self.bot.send_message(message)
 
-        attachments = """
+        expected_attachments = """
         [
             {
                 "fallback":"fallback",
@@ -502,7 +502,7 @@ class TestSendMessageWithMessageAttachmentsDictionary(TestPhialBot):
                 'chat.postMessage',
                 channel='channel_id',
                 as_user=True,
-                attachments=json.dumps(json.loads(attachments)),
+                attachments=json.dumps(json.loads(expected_attachments)),
                 text=None)
 
 


### PR DESCRIPTION
This PR will close https://github.com/sedders123/phial/issues/36
Attachments can be passed down as an instance of `MessageAttachment` or a dictionary.