### PR TITLE
Allow ephemeral messages to be sent

### DIFF
--- a/phial/bot.py
+++ b/phial/bot.py
@@ -279,22 +279,28 @@ class Phial():
             message(Response): message object to be sent to Slack
 
         '''
+
+        api_method = ('chat.postEphemeral' if message.ephemeral
+                      else 'chat.postMessage')
+
         if message.original_ts:
-            self.slack_client.api_call("chat.postMessage",
+            self.slack_client.api_call(api_method,
                                        channel=message.channel,
                                        text=message.text,
                                        thread_ts=message.original_ts,
                                        attachments=json.dumps(
                                            message.attachments,
                                            default=lambda o: o.__dict__),
+                                       user=message.user,
                                        as_user=True)
         else:
-            self.slack_client.api_call("chat.postMessage",
+            self.slack_client.api_call(api_method,
                                        channel=message.channel,
                                        text=message.text,
                                        attachments=json.dumps(
                                            message.attachments,
                                            default=lambda o: o.__dict__),
+                                       user=message.user,
                                        as_user=True)
 
     def send_reaction(self, response: Response) -> None:

--- a/phial/wrappers.py
+++ b/phial/wrappers.py
@@ -198,7 +198,7 @@ class Response():
                  attachments: Optional[Union[List[MessageAttachment],
                                        List[MessageAttachmentJson]]] = None,
                  reaction: Optional[str] = None,
-                 ephemeral: Optional[bool] = False,
+                 ephemeral: bool = False,
                  user: Optional[str] = None) -> None:
         self.channel = channel
         self.text = text

--- a/phial/wrappers.py
+++ b/phial/wrappers.py
@@ -164,6 +164,8 @@ class Response():
                           List[Dict[str, Dict[str, str]]]]):
                           A list of MessageAttachment objects to be attached
                           to the message
+        ephemeral(bool): Whether to send the message as an ephemeral message
+        user(str): The user id to display the ephemeral message to
 
     Examples:
         The following would send a message to a slack channel when executed ::
@@ -195,12 +197,16 @@ class Response():
                  original_ts: Optional[str] = None,
                  attachments: Optional[Union[List[MessageAttachment],
                                        List[MessageAttachmentJson]]] = None,
-                 reaction: Optional[str] = None) -> None:
+                 reaction: Optional[str] = None,
+                 ephemeral: Optional[bool] = False,
+                 user: Optional[str] = None) -> None:
         self.channel = channel
         self.text = text
         self.original_ts = original_ts
         self.reaction = reaction
         self.attachments = attachments
+        self.ephemeral = ephemeral
+        self.user = user
 
     def __repr__(self) -> str:
         return "<Response: {0}>".format(self.text)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -513,7 +513,7 @@ class TestSendMessageWithMessageAttachmentsDictionary(TestPhialBot):
 class TestSendEphemeralMessage(TestPhialBot):
     '''Test phial's send_message function when sending an ephemeral message'''
 
-    def test_send_message(self):
+    def test_ephemeral(self):
         self.bot.slack_client = MagicMock()
         message = Response(channel="channel_id",
                            ephemeral=True,
@@ -529,12 +529,7 @@ class TestSendEphemeralMessage(TestPhialBot):
                 text='Test text',
                 user='user_id')
 
-
-class TestSendMessageDefaultsEphemeralToFalse(TestPhialBot):
-    '''Test phial's send_message function does not send ephemeral
-       messages by default'''
-
-    def test_send_message(self):
+    def test_ephemeral_defaults_to_false(self):
         self.bot.slack_client = MagicMock()
         message = Response(channel="channel_id",
                            text="Test text")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -346,7 +346,8 @@ class TestSendMessage(TestPhialBot):
                                                           channel='channel_id',
                                                           text='Hi test',
                                                           as_user=True,
-                                                          attachments='null')
+                                                          attachments='null',
+                                                          user=None)
 
     def test_send_reply(self):
         self.bot.slack_client = MagicMock()
@@ -362,7 +363,8 @@ class TestSendMessage(TestPhialBot):
                                 text='Hi test',
                                 thread_ts='timestamp',
                                 as_user=True,
-                                attachments='null')
+                                attachments='null',
+                                user=None)
 
 
 class TestSendMessageWithMessageAttachments(TestPhialBot):
@@ -430,7 +432,8 @@ class TestSendMessageWithMessageAttachments(TestPhialBot):
                 channel='channel_id',
                 as_user=True,
                 attachments=json.dumps(json.loads(attachments)),
-                text=None)
+                text=None,
+                user=None)
 
 
 class TestSendMessageWithMessageAttachmentsDictionary(TestPhialBot):
@@ -503,7 +506,47 @@ class TestSendMessageWithMessageAttachmentsDictionary(TestPhialBot):
                 channel='channel_id',
                 as_user=True,
                 attachments=json.dumps(json.loads(expected_attachments)),
-                text=None)
+                text=None,
+                user=None)
+
+
+class TestSendEphemeralMessage(TestPhialBot):
+    '''Test phial's send_message function when sending an ephemeral message'''
+
+    def test_send_message(self):
+        self.bot.slack_client = MagicMock()
+        message = Response(channel="channel_id",
+                           ephemeral=True,
+                           text="Test text",
+                           user="user_id")
+        self.bot.send_message(message)
+
+        self.bot.slack_client.api_call.assert_called_with(
+                'chat.postEphemeral',
+                channel='channel_id',
+                as_user=True,
+                attachments='null',
+                text='Test text',
+                user='user_id')
+
+
+class TestSendMessageDefaultsEphemeralToFalse(TestPhialBot):
+    '''Test phial's send_message function does not send ephemeral
+       messages by default'''
+
+    def test_send_message(self):
+        self.bot.slack_client = MagicMock()
+        message = Response(channel="channel_id",
+                           text="Test text")
+        self.bot.send_message(message)
+
+        self.bot.slack_client.api_call.assert_called_with(
+                'chat.postMessage',
+                channel='channel_id',
+                as_user=True,
+                attachments='null',
+                text='Test text',
+                user=None)
 
 
 class TestSendReaction(TestPhialBot):


### PR DESCRIPTION
This closes #38 by allowing ephemeral message to be sent.
If the ephemeral flag is not set, it defaults to `false` and a regular message will be sent.