### PR TITLE
Configure default logger to give output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
  - Built-in help command. Uses docstrings as help text unless overridden
+### Changed
+ - Default logger level changed to INFO
 
 ## [0.3.0](https://github.com/sedders123/phial/releases/tag/0.3.0) - 2018-08-05
 ### Added

--- a/phial/bot.py
+++ b/phial/bot.py
@@ -26,15 +26,23 @@ class Phial():
     def __init__(self,
                  token: str,
                  config: dict = default_config,
-                 logger: logging.Logger = logging.getLogger(__name__)) -> None:
+                 logger: Optional[logging.Logger] = None) -> None:
         self.slack_client = SlackClient(token)
         self.commands = {}  # type: Dict[Pattern[str], Callable]
         self.command_names = {}  # type: Dict[Pattern[str], str]
         self.middleware_functions = []  # type: List[Callable]
         self.config = config
         self.running = False
-        self.logger = logger
         self.scheduler = Scheduler()
+        if logger is None:
+            logger = logging.getLogger(__name__)
+            if not logger.hasHandlers():
+                handler = logging.StreamHandler()
+                formatter = logging.Formatter(fmt="%(asctime)s - %(message)s")
+                handler.setFormatter(formatter)
+                logger.addHandler(handler)
+            logger.setLevel(logging.INFO)
+        self.logger = logger
 
         _global_ctx_stack.push({})
         self._register_standard_commands()


### PR DESCRIPTION
## Description
Changes the default logger to give info level output to the terminal.

## Motivation and Context
Provide a better experience for users, by being able to see the 'ready' message.
Closes #58 

## Types of changes
Put an x in all boxes that apply
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Put an x in all boxes that apply
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have added/updated docstrings to the code I have touched.
- [x] All new and existing tests passed.
- [x] I have updated the Changelog to reflect my changes
