### PR TITLE
Add a fallback function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
  - Built-in help command. Uses docstrings as help text unless overridden
+ - Added the ability to specify a 'fallback' command for when a user attempts to use an invalid command
 ### Changed
  - Default logger level changed to INFO
 

--- a/examples/starter.py
+++ b/examples/starter.py
@@ -70,6 +70,9 @@ def case_sensitive():
     '''Simple command which replies with a message'''
     return "You typed caseSensitive"
 
+@slackbot.fallback_command()
+def fallback_command(command):
+    return "Thats a not a command"
 
 if __name__ == '__main__':
     slackbot.run()

--- a/phial/bot.py
+++ b/phial/bot.py
@@ -170,7 +170,7 @@ class Phial():
             return f
         return decorator
 
-    def add_fallback_command(self, command_func):
+    def add_fallback_command(self, command_func: Callable) -> None:
         '''
         Registers a fallback function to run when a user tries to execute a
         command that doesn't exist. This is the same as
@@ -397,7 +397,7 @@ class Phial():
         '''Executes a given command'''
         if command is None:
             return  # Do nothing if no command
-        command_func = self.commands[command.command_pattern]
+        command_func = self.commands.get(command.command_pattern, None)
         if command_func is None:
             # If no command found warn and then return early
             self.logger.warn("Command for pattern {0} not found"

--- a/phial/bot.py
+++ b/phial/bot.py
@@ -413,15 +413,15 @@ class Phial():
 
         if command_func is None:
             # If no command found warn and then return early
-            self.logger.warn("Command for pattern {0} not found"
-                             .format(command.command_pattern))
+            self.logger.warn("Command {0} not found"
+                             .format(command.message.text))
             if self.fallback_command_func is None:
                 return
             _command_ctx_stack.push(command)
             return self.fallback_command_func(command)
         if command.args is None:
             self.logger.exception("Command has no args")
-            raise ValueError("")
+            raise ValueError("Command has no args")
         _command_ctx_stack.push(command)
         return command_func(**command.args)
 
@@ -559,7 +559,6 @@ class Phial():
         try:
             command = self._create_command(message)
             response = self._handle_command(command)
-            print(response)
             self._execute_response(response)
         except ValueError as err:
             self.logger.exception('ValueError: {}'.format(err))

--- a/phial/wrappers.py
+++ b/phial/wrappers.py
@@ -50,9 +50,9 @@ class Command():
         message_text(`Message`): The message that initiated the command
     '''
     def __init__(self,
-                 command_pattern: Pattern[str],
+                 command_pattern: Optional[Pattern[str]],
                  channel: str,
-                 args: Dict,
+                 args: Optional[Dict],
                  user: str,
                  message: Message) -> None:
         self.command_pattern = command_pattern

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -58,6 +58,7 @@ class TestCommandDecarator(TestPhialBot):
                                                 False,
                                                 None)
 
+
 class TestFallbackCommandDecarator(TestPhialBot):
     '''Tests for phial's fallback command decorator'''
 
@@ -341,7 +342,6 @@ class TestHandleCommand(TestPhialBot):
         result = self.bot._handle_command(None)
 
         self.assertEqual(result, None)
-
 
 
 class TestCommandContextWorksCorrectly(TestPhialBot):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -306,15 +306,18 @@ class TestCreateCommand(TestPhialBot):
                                                   command_message)
         self.assertEqual(command, expected_command)
 
-    def test_errors_when_no_command_match(self):
-        with self.assertRaises(ValueError) as context:
-            command_message = phial.wrappers.Message('!test',
-                                                     'channel_id',
-                                                     'user',
-                                                     'timestamp')
-            self.bot._create_command(command_message)
-        self.assertTrue('Command "test" has not been registered'
-                        in str(context.exception))
+    def test_returns_partialcommand_when_no__command_match(self):
+        command_message = phial.wrappers.Message('!test',
+                                                 'channel_id',
+                                                 'user',
+                                                 'timestamp')
+        expected_result = phial.wrappers.Command(None,
+                                                 'channel_id',
+                                                 None,
+                                                 'user',
+                                                 command_message)
+        result = self.bot._create_command(command_message)
+        self.assertEqual(result, expected_result)
 
 
 class TestHandleCommand(TestPhialBot):
@@ -915,8 +918,8 @@ class TestRun(TestPhialBot):
                                               'timestamp')
         self.bot._parse_slack_output = MagicMock(return_value=test_command)
 
-        expected_msg = 'ValueError: Command "test" has not been registered'
-        with self.assertLogs(logger='phial.bot', level='ERROR') as cm:
+        expected_msg = 'Command !test not found'
+        with self.assertLogs(logger='phial.bot', level='WARN') as cm:
             self.bot.run()
 
             error = cm.output[0]


### PR DESCRIPTION
## Description
Add the ability for a user to specify to 'fallback' function. This will be executed whenever an end user tries to run an invalid command. The fallback command is given a `Command` object which can be used to customise the response based on the command that was attempted to be run.

## Motivation and Context
Closes #51 

## Types of changes
Put an x in all boxes that apply
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Put an x in all boxes that apply
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have added/updated docstrings to the code I have touched.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the Changelog to reflect my changes
- [x] Has the changes been tested against a real Slack instance?
