### PR TITLE
Strip command help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+ - Help command now works better with multiline doc strings. The command now ignores single new lines and converts double new lines into single new lines, similar to markdown.
 
 ## [0.4.0](https://github.com/sedders123/phial/releases/tag/0.3.0) - 2018-08-30
 ### Added

--- a/examples/starter.py
+++ b/examples/starter.py
@@ -10,6 +10,15 @@ def ping():
     return "Pong"
 
 
+@slackbot.command('pong')
+def pong():
+    '''
+    Simple command which replies with a message. Has a mutiline
+    docstring.
+    '''
+    return "Ping"
+
+
 @slackbot.command('hello <name>')
 def hello(name):
     '''Simple command with argument which replies to a message'''

--- a/phial/commands.py
+++ b/phial/commands.py
@@ -14,6 +14,7 @@ def help_command(bot: 'Phial') -> str:
         # deal with 'extending' functions to have extra attributes
         # GitHub Issue: https://github.com/python/mypy/issues/2087
         command_doc = bot.commands[command]._help  # type: ignore
+        escaped_command_doc = command_doc.strip()
         command_name = bot.command_names[command]
-        help_text += "*{0}* - {1}\n".format(command_name, command_doc)
+        help_text += "*{0}* - {1}\n".format(command_name, escaped_command_doc)
     return help_text

--- a/phial/commands.py
+++ b/phial/commands.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from phial import Phial  # noqa
 
+NEW_LINE_SEPERATOR = "<NEW_LINE_SEPERATOR>"
 
 def help_command(bot: 'Phial') -> str:
     '''List all regsitered commmands'''
@@ -14,7 +15,9 @@ def help_command(bot: 'Phial') -> str:
         # deal with 'extending' functions to have extra attributes
         # GitHub Issue: https://github.com/python/mypy/issues/2087
         command_doc = bot.commands[command]._help  # type: ignore
-        escaped_command_doc = command_doc.strip()
+        stripped_command_doc = command_doc.strip()
+        escaped_command_doc = stripped_command_doc.replace("\n",NEW_LINE_SEPERATOR) \
+            .replace(NEW_LINE_SEPERATOR * 2, "\n").replace(NEW_LINE_SEPERATOR, "")
         command_name = bot.command_names[command]
         help_text += "*{0}* - {1}\n".format(command_name, escaped_command_doc)
     return help_text

--- a/phial/commands.py
+++ b/phial/commands.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING
+from phial.utils import parse_help_text
 
 if TYPE_CHECKING:
     from phial import Phial  # noqa
 
-NEW_LINE_SEPERATOR = "<NEW_LINE_SEPERATOR>"
 
 def help_command(bot: 'Phial') -> str:
     '''List all regsitered commmands'''
@@ -15,9 +15,7 @@ def help_command(bot: 'Phial') -> str:
         # deal with 'extending' functions to have extra attributes
         # GitHub Issue: https://github.com/python/mypy/issues/2087
         command_doc = bot.commands[command]._help  # type: ignore
-        stripped_command_doc = command_doc.strip()
-        escaped_command_doc = stripped_command_doc.replace("\n",NEW_LINE_SEPERATOR) \
-            .replace(NEW_LINE_SEPERATOR * 2, "\n").replace(NEW_LINE_SEPERATOR, "")
+        commnad_help_text = parse_help_text(command_doc)
         command_name = bot.command_names[command]
-        help_text += "*{0}* - {1}\n".format(command_name, escaped_command_doc)
+        help_text += "*{0}* - {1}\n".format(command_name, commnad_help_text)
     return help_text

--- a/phial/utils.py
+++ b/phial/utils.py
@@ -1,0 +1,18 @@
+import re
+
+
+def parse_help_text(help_text: str) -> str:
+    NEW_LINE_SEPERATOR = "<__NEW_LINE_SEPERATOR__>"
+
+    # Strip excess whitespace
+    help_text = help_text.strip()
+
+    # Remove single new lines
+    help_text = help_text.replace("\n", NEW_LINE_SEPERATOR)
+    help_text = help_text.replace(NEW_LINE_SEPERATOR * 2, "\n")
+    help_text = help_text.replace(NEW_LINE_SEPERATOR, "")
+
+    # Remove extra spaces
+    help_text = re.sub(r'(^[ \t]+|[ \t]+)', ' ', help_text, flags=re.M)
+
+    return help_text

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -95,3 +95,21 @@ class TestHelpCommand(unittest.TestCase):
 
         help_text = help_command(bot)
         self.assertEqual(help_text, expected_help_text)
+
+    def test_help_command_parses_multiline_docstring_correctty(self):
+        bot = MagicMock()
+        command = MagicMock()
+
+        command._help = """
+        Test of multiline
+        docstring
+        """
+
+        bot.commands = {"test_pattern": command}
+        bot.command_names = {"test_pattern": "test"}
+        bot.config = {'baseHelpText': "Base text"}
+
+        expected_help_text = "Base text\n*test* - Test of multiline docstring\n"
+
+        help_text = help_command(bot)
+        self.assertEqual(help_text, expected_help_text)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -91,7 +91,8 @@ class TestHelpCommand(unittest.TestCase):
         bot.command_names = {"test_pattern": "test"}
         bot.config = {'baseHelpText': "Base text"}
 
-        expected_help_text = "Base text\n*test* - Test description\n on a new line\n"
+        expected_help_text = "Base text\n*test* - Test description\n" \
+                             + " on a new line\n"
 
         help_text = help_command(bot)
         self.assertEqual(help_text, expected_help_text)
@@ -109,7 +110,8 @@ class TestHelpCommand(unittest.TestCase):
         bot.command_names = {"test_pattern": "test"}
         bot.config = {'baseHelpText': "Base text"}
 
-        expected_help_text = "Base text\n*test* - Test of multiline docstring\n"
+        expected_help_text = "Base text\n*test* - Test of multiline" \
+                             + " docstring\n"
 
         help_text = help_command(bot)
         self.assertEqual(help_text, expected_help_text)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -80,3 +80,18 @@ class TestHelpCommand(unittest.TestCase):
 
         help_text = help_command(bot)
         self.assertEqual(help_text, expected_help_text)
+
+    def test_help_command_strips_single_newlines(self):
+        bot = MagicMock()
+        command = MagicMock()
+
+        command._help = "\n     Test\n description\n\n on a new line     \n"
+
+        bot.commands = {"test_pattern": command}
+        bot.command_names = {"test_pattern": "test"}
+        bot.config = {'baseHelpText': "Base text"}
+
+        expected_help_text = "Base text\n*test* - Test description\n on a new line\n"
+
+        help_text = help_command(bot)
+        self.assertEqual(help_text, expected_help_text)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -50,3 +50,33 @@ class TestHelpCommand(unittest.TestCase):
 
         help_text = help_command(bot)
         self.assertEqual(help_text, expected_help_text)
+
+    def test_help_command_strips_newlines(self):
+        bot = MagicMock()
+        command = MagicMock()
+
+        command._help = "\nTest description\n"
+
+        bot.commands = {"test_pattern": command}
+        bot.command_names = {"test_pattern": "test"}
+        bot.config = {'baseHelpText': "Base text"}
+
+        expected_help_text = "Base text\n*test* - Test description\n"
+
+        help_text = help_command(bot)
+        self.assertEqual(help_text, expected_help_text)
+
+    def test_help_command_strips_whitespace(self):
+        bot = MagicMock()
+        command = MagicMock()
+
+        command._help = "\n     Test description     \n"
+
+        bot.commands = {"test_pattern": command}
+        bot.command_names = {"test_pattern": "test"}
+        bot.config = {'baseHelpText': "Base text"}
+
+        expected_help_text = "Base text\n*test* - Test description\n"
+
+        help_text = help_command(bot)
+        self.assertEqual(help_text, expected_help_text)


### PR DESCRIPTION
## Description
Strip the command help text before adding it to the returned string.

## Motivation and Context
When docstrings are spread across multiple lines there are leading and trailing newlines, these changes stop these from appearing in the !help command
Closes #63.

## How Has This Been Tested?
Unit Tests have been added

## Types of changes
Put an x in all boxes that apply
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Put an x in all boxes that apply
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the Changelog to reflect my changes
- [x] The changes have been tested against a real Slack instance
