### PR TITLE
Support quotation marks around command params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
  - Help command now works better with multiline doc strings. The command now ignores single new lines and converts double new lines into single new lines, similar to markdown.
+ - Parameters of commands can now be wrapped in double quotation marks to allow for values containing whitespace.
 
 ## [0.4.0](https://github.com/sedders123/phial/releases/tag/0.3.0) - 2018-08-30
 ### Added

--- a/examples/starter.py
+++ b/examples/starter.py
@@ -25,6 +25,13 @@ def hello(name):
     return Response(text="Hi {0}".format(name), channel=command.channel)
 
 
+@slackbot.command('hello <name> <from_>')
+def hello(name, from_):
+    '''Simple command with two arguments which replies to a message'''
+    return Response(text="Hi {0}, from {1}".format(name, from_),
+                    channel=command.channel)
+
+
 @slackbot.command('react')
 def react():
     '''Simple command that reacts to the original message'''

--- a/phial/bot.py
+++ b/phial/bot.py
@@ -62,7 +62,9 @@ class Phial():
     def _build_command_pattern(command: str,
                                case_sensitive: bool) -> Pattern[str]:
         '''Creates the command pattern regexs'''
-        command_regex = re.sub(r'(<\w+>)', r'(?P\1.+)', command)
+
+        command = re.sub(r'(<\w+>)', r'(\"?\1\"?)', command)
+        command_regex = re.sub(r'(<\w+>)', r'(?P\1[^"]*)', command)
         return re.compile("^{}$".format(command_regex),
                           0 if case_sensitive else re.IGNORECASE)
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -205,44 +205,77 @@ class TestBuildCommandPattern(TestPhialBot):
         command_template = 'test'
         command_pattern = self.bot._build_command_pattern(command_template,
                                                           False)
-        expected_result = re.compile('^test$', re.IGNORECASE)
-        self.assertTrue(command_pattern == expected_result)
+        match = command_pattern.match("test")
+        self.assertTrue(match is not None)
 
     def test_build_command_pattern_single_substition_ignore_case(self):
         command_template = 'test <one>'
         command_pattern = self.bot._build_command_pattern(command_template,
                                                           False)
-        expected_result = re.compile('^test (?P<one>.+)$', re.IGNORECASE)
-        self.assertTrue(command_pattern == expected_result)
+        match_dict = command_pattern.match("test one").groupdict()
+        self.assertTrue(match_dict['one'] is not None)
 
     def test_build_command_pattern_multiple_substition_ignore_case(self):
         command_template = 'test <one> <two>'
         command_pattern = self.bot._build_command_pattern(command_template,
                                                           False)
-        expected_result = re.compile('^test (?P<one>.+) (?P<two>.+)$',
-                                     re.IGNORECASE)
-        self.assertTrue(command_pattern == expected_result)
+        match_dict = command_pattern.match("test one two").groupdict()
+        self.assertTrue(match_dict['one'] is not None)
+        self.assertTrue(match_dict['two'] is not None)
 
     def test_build_command_pattern_no_substition_case_sensitive(self):
         command_template = 'tEst'
         command_pattern = self.bot._build_command_pattern(command_template,
                                                           True)
-        expected_result = re.compile('^tEst$')
-        self.assertTrue(command_pattern == expected_result)
+        self.assertTrue(command_pattern.match("tEst") is not None)
+        self.assertTrue(command_pattern.match("Test") is None)
+
 
     def test_build_command_pattern_single_substition_case_sensitive(self):
         command_template = 'tEst <one>'
         command_pattern = self.bot._build_command_pattern(command_template,
                                                           True)
-        expected_result = re.compile('^tEst (?P<one>.+)$')
-        self.assertTrue(command_pattern == expected_result)
+
+        match_dict = command_pattern.match("tEst one").groupdict()
+        self.assertTrue(match_dict['one'] is not None)
+        self.assertTrue(command_pattern.match("Test one") is None)
 
     def test_build_command_pattern_multiple_substition_case_sensitive(self):
         command_template = 'tEst <one> <two>'
         command_pattern = self.bot._build_command_pattern(command_template,
                                                           True)
-        expected_result = re.compile('^tEst (?P<one>.+) (?P<two>.+)$')
-        self.assertTrue(command_pattern == expected_result)
+        match_dict = command_pattern.match("tEst one two").groupdict()
+        self.assertTrue(match_dict['one'] is not None)
+        self.assertTrue(match_dict['two'] is not None)
+        self.assertTrue(command_pattern.match("Test one") is None)
+
+    def test_build_command_allows_quotation_marks(self):
+        command_template = 'test <one> <two>'
+        command_pattern = self.bot._build_command_pattern(command_template,
+                                                          False)
+        match_dict = command_pattern.match("test \"one two\" three").groupdict()
+        print(match_dict)
+        self.assertTrue(match_dict['one'] == "one two")
+        self.assertTrue(match_dict['two'] == "three")
+
+    def test_build_command_allows_all_params_with_quotation_marks(self):
+        command_template = 'test <one> <two>'
+        command_pattern = self.bot._build_command_pattern(command_template,
+                                                          False)
+        match_dict = command_pattern.match("test \"one two\" \"three\"").groupdict()
+        print(match_dict)
+        self.assertTrue(match_dict['one'] == "one two")
+        self.assertTrue(match_dict['two'] == "three")
+
+    def test_build_command_allows_multiple_params_with_quotation_marks(self):
+        command_template = 'test <one> <two> <three>'
+        command_pattern = self.bot._build_command_pattern(command_template,
+                                                          False)
+        match_dict = command_pattern.match("test \"one two\" three \"four\"").groupdict()
+        print(match_dict)
+        self.assertTrue(match_dict['one'] == "one two")
+        self.assertTrue(match_dict['two'] == "three")
+        self.assertTrue(match_dict['three'] == "four")
 
 
 class TestGetCommandMatch(TestPhialBot):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -230,7 +230,6 @@ class TestBuildCommandPattern(TestPhialBot):
         self.assertTrue(command_pattern.match("tEst") is not None)
         self.assertTrue(command_pattern.match("Test") is None)
 
-
     def test_build_command_pattern_single_substition_case_sensitive(self):
         command_template = 'tEst <one>'
         command_pattern = self.bot._build_command_pattern(command_template,
@@ -253,7 +252,8 @@ class TestBuildCommandPattern(TestPhialBot):
         command_template = 'test <one> <two>'
         command_pattern = self.bot._build_command_pattern(command_template,
                                                           False)
-        match_dict = command_pattern.match("test \"one two\" three").groupdict()
+        match_dict = command_pattern.match("test \"one two\" three") \
+            .groupdict()
         print(match_dict)
         self.assertTrue(match_dict['one'] == "one two")
         self.assertTrue(match_dict['two'] == "three")
@@ -262,7 +262,8 @@ class TestBuildCommandPattern(TestPhialBot):
         command_template = 'test <one> <two>'
         command_pattern = self.bot._build_command_pattern(command_template,
                                                           False)
-        match_dict = command_pattern.match("test \"one two\" \"three\"").groupdict()
+        match_dict = command_pattern.match("test \"one two\" \"three\"") \
+            .groupdict()
         print(match_dict)
         self.assertTrue(match_dict['one'] == "one two")
         self.assertTrue(match_dict['two'] == "three")
@@ -271,7 +272,8 @@ class TestBuildCommandPattern(TestPhialBot):
         command_template = 'test <one> <two> <three>'
         command_pattern = self.bot._build_command_pattern(command_template,
                                                           False)
-        match_dict = command_pattern.match("test \"one two\" three \"four\"").groupdict()
+        match_dict = command_pattern.match("test \"one two\" three \"four\"") \
+            .groupdict()
         print(match_dict)
         self.assertTrue(match_dict['one'] == "one two")
         self.assertTrue(match_dict['two'] == "three")


### PR DESCRIPTION
## Description
Commands from slack can now wrap parameters in double quotation marks. e..g `!hello "long name" 2`

## Motivation and Context
Multiple parameters are currently a pain to deal with.
Closes #48 

## Types of changes
Put an x in all boxes that apply
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Put an x in all boxes that apply
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the Changelog to reflect my changes
- [x] Has the changes been tested against a real Slack instance?
