### PR TITLE
Allow config to be partially updated

### DIFF
--- a/phial/bot.py
+++ b/phial/bot.py
@@ -32,7 +32,8 @@ class Phial():
         self.commands = {}  # type: Dict[Pattern[str], Callable]
         self.command_names = {}  # type: Dict[Pattern[str], str]
         self.middleware_functions = []  # type: List[Callable]
-        self.config = config
+        self.config = dict(self.default_config)
+        self.config.update(config)
         self.running = False
         self.scheduler = Scheduler()
         self.fallback_command_func = None  # type: Optional[Callable]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -35,6 +35,35 @@ class TestPhialBot(unittest.TestCase):
                         in self.bot.commands)
 
 
+class TestPhialBotConfig(TestPhialBot):
+    '''Tests for phial's config'''
+
+    def test_uses_default_config_when_specified(self):
+        bot = Phial('test-token')
+        self.assertEqual(bot.config, Phial.default_config)
+
+    def test_config_override(self):
+        bot = Phial('test-token', config={
+            'prefix': "/",
+            'registerHelpCommand': False,
+            'baseHelpText': "All commands:",
+            'autoReconnect': False
+        })
+        self.assertEqual(bot.config, {
+            'prefix': "/",
+            'registerHelpCommand': False,
+            'baseHelpText': "All commands:",
+            'autoReconnect': False
+        })
+
+    def test_partial_config_override(self):
+        bot = Phial('test-token', config={
+            'prefix': "/",
+        })
+        self.assertEqual(bot.config['prefix'], '/')
+        self.assertEqual(bot.config['baseHelpText'], "All available commands:")
+
+
 class TestCommandDecarator(TestPhialBot):
     '''Tests for phial's command decorator'''
 


### PR DESCRIPTION
## Description
Allow configuration to be partially updated.

## Motivation and Context
This allows only some configuration variables to be changed, whilst leaving the defaults in-tact.

## Types of changes
Put an x in all boxes that apply
- [x] Bug fix (non-breaking change which fixes an issue) (kinda)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Put an x in all boxes that apply
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have added/updated docstrings to the code I have touched.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the Changelog to reflect my changes
- [ ] Has the changes been tested against a real Slack instance?
