### PR TITLE
Add Team ID to Command and Message classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+ - Add `team` attribute to `Message` and `Command` models. This stores the ID of the Slack Team that the call originated from.
 ### Changed
  - Allow configuration to be partially updated ([@RealOrangeOne](https://github.com/RealOrangeOne) in [#81](https://github.com/sedders123/phial/pull/81))
 ### Fixed

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ nose==1.3.7
 coveralls
 twine==1.12.1
 mypy==0.641
+freezegun==0.3.11

--- a/examples/starter.py
+++ b/examples/starter.py
@@ -90,7 +90,7 @@ def case_sensitive():
 @slackbot.command('messageWithAttachment')
 def get_message_with_attachment():
     '''
-        A command that posts a message with a Slack attachment    
+        A command that posts a message with a Slack attachment
         Read more: https://api.slack.com/docs/message-attachments
     '''
     attachments = [{

--- a/phial/bot.py
+++ b/phial/bot.py
@@ -398,14 +398,16 @@ class Phial():
                            command_message.channel,
                            None,
                            command_message.user,
-                           command_message)
+                           command_message,
+                           command_message.team)
         if command_match:
             kwargs, command_pattern = command_match
             return Command(command_pattern,
                            command_message.channel,
                            kwargs,
                            command_message.user,
-                           command_message)
+                           command_message,
+                           command_message.team)
         return None
 
     def _handle_command(self, command: Optional[Command]) -> Any:
@@ -451,6 +453,7 @@ class Phial():
                                    output['channel'],
                                    output['user'],
                                    output['ts'],
+                                   output['team'],
                                    bot_id)
         return None
 

--- a/phial/wrappers.py
+++ b/phial/wrappers.py
@@ -22,17 +22,20 @@ class Message():
                  channel: str,
                  user: str,
                  timestamp: str,
+                 team: str,
                  bot_id: Optional[str] = None) -> None:
         self.text = text
         self.channel = channel
         self.user = user
         self.timestamp = timestamp
+        self.team = team
         self.bot_id = bot_id
 
     def __repr__(self) -> str:
-        return "<Message: {0} in {1} at {2}>".format(self.text,
-                                                     self.channel,
-                                                     self.timestamp)
+        return "<Message: {0} in {1}:{2} at {3}>".format(self.text,
+                                                         self.channel,
+                                                         self.team,
+                                                         self.timestamp)
 
     def __eq__(self, other: object) -> bool:
         return self.__dict__ == other.__dict__
@@ -54,17 +57,21 @@ class Command():
                  channel: str,
                  args: Optional[Dict],
                  user: str,
-                 message: Message) -> None:
+                 message: Message,
+                 team: str) -> None:
         self.command_pattern = command_pattern
         self.channel = channel
         self.args = args
         self.user = user
         self.message = message
         self.message_ts = message.timestamp
+        self.team = team
 
     def __repr__(self) -> str:
-        return "<Command: {0}, {1} in {2}>".format(self.message,
-                                                   self.args, self.channel)
+        return "<Command: {0}, {1} in {2}:{3}>".format(self.message.text,
+                                                       self.args,
+                                                       self.channel,
+                                                       self.team)
 
     def __eq__(self, other: object) -> bool:
         return self.__dict__ == other.__dict__

--- a/phial/wrappers.py
+++ b/phial/wrappers.py
@@ -12,7 +12,9 @@ class Message():
         text(str): The message contents
         channel(str): The Slack channel ID the message was sent from
         user(str): The user who sent the message
-        timestamp(str): The messages timestamp
+        timestamp(str): The message's timestamp
+        team(str): The Team ID of the Slack workspace the message was
+                   sent from
         bot_id(str, optional): If the message was sent by a bot
                                the ID of that bot.
                                Defaults to None.
@@ -50,7 +52,11 @@ class Command():
         channel(str): The Slack channel ID the command was called from
         args(dict): Any arguments passed to the command
         user(str): The Slack User ID of the user who intiated the command
-        message_text(`Message`): The message that initiated the command
+        message(`Message`): The message that initiated the command
+        message_ts(str): The timestamp of the message that initiated the
+                         command
+        team(str): The Team ID of the Slack workspace the command was
+                   called from
     '''
     def __init__(self,
                  command_pattern: Optional[Pattern[str]],

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -200,13 +200,15 @@ class TestFallbackCommand(TestPhialBot):
         message = phial.wrappers.Message(text="!test",
                                          channel="channel_id",
                                          user="user",
-                                         timestamp="timestamp")
+                                         timestamp="timestamp",
+                                         team="team")
         command_patern = re.compile('^test$')
         command = phial.wrappers.Command(command_patern,
                                          'channel_id',
                                          {},
                                          'user',
-                                         message)
+                                         message,
+                                         'team')
 
         result = self.bot._handle_command(command)
         self.assertEqual(result, "oops")
@@ -215,13 +217,15 @@ class TestFallbackCommand(TestPhialBot):
         message = phial.wrappers.Message(text="!test",
                                          channel="channel_id",
                                          user="user",
-                                         timestamp="timestamp")
+                                         timestamp="timestamp",
+                                         team="team")
         command_patern = re.compile('^test$')
         command = phial.wrappers.Command(command_patern,
                                          'channel_id',
                                          {},
                                          'user',
-                                         message)
+                                         message,
+                                         'team')
 
         result = self.bot._handle_command(command)
         self.assertEqual(result, None)
@@ -346,13 +350,15 @@ class TestCreateCommand(TestPhialBot):
         command_message = phial.wrappers.Message('!test',
                                                  'channel_id',
                                                  'user',
-                                                 'timestamp')
+                                                 'timestamp',
+                                                 'team')
         command = self.bot._create_command(command_message)
         expected_command = phial.wrappers.Command(command_patern,
                                                   'channel_id',
                                                   {},
                                                   'user',
-                                                  command_message)
+                                                  command_message,
+                                                  'team')
         self.assertEqual(command, expected_command)
 
     def test_basic_functionality_with_args(self):
@@ -361,25 +367,29 @@ class TestCreateCommand(TestPhialBot):
         command_message = phial.wrappers.Message('!test first',
                                                  'channel_id',
                                                  'user',
-                                                 'timestamp')
+                                                 'timestamp',
+                                                 'team')
         command = self.bot._create_command(command_message)
         expected_command = phial.wrappers.Command(command_patern,
                                                   'channel_id',
                                                   {'one': 'first'},
                                                   'user',
-                                                  command_message)
+                                                  command_message,
+                                                  'team')
         self.assertEqual(command, expected_command)
 
     def test_returns_partialcommand_when_no__command_match(self):
         command_message = phial.wrappers.Message('!test',
                                                  'channel_id',
                                                  'user',
-                                                 'timestamp')
+                                                 'timestamp',
+                                                 'team')
         expected_result = phial.wrappers.Command(None,
                                                  'channel_id',
                                                  None,
                                                  'user',
-                                                 command_message)
+                                                 command_message,
+                                                 'team')
         result = self.bot._create_command(command_message)
         self.assertEqual(result, expected_result)
 
@@ -394,13 +404,15 @@ class TestHandleCommand(TestPhialBot):
         message = phial.wrappers.Message(text="!test",
                                          channel="channel_id",
                                          user="user",
-                                         timestamp="timestamp")
+                                         timestamp="timestamp",
+                                         team="team")
         command_patern = self.bot._build_command_pattern('test', False)
         command_instance = phial.wrappers.Command(command_patern,
                                                   'channel_id',
                                                   {},
                                                   'user',
-                                                  message)
+                                                  message,
+                                                  'team')
         self.bot._handle_command(command_instance)
 
         self.assertTrue(test_func.called)
@@ -425,12 +437,14 @@ class TestCommandContextWorksCorrectly(TestPhialBot):
         message = phial.wrappers.Message(text="!test",
                                          channel="channel_id",
                                          user="user",
-                                         timestamp="timestamp")
+                                         timestamp="timestamp",
+                                         team="team")
         command_instance = phial.wrappers.Command(command_pattern,
                                                   'channel_id',
                                                   {},
                                                   'user',
-                                                  message)
+                                                  message,
+                                                  "team")
         self.bot._handle_command(command_instance)
 
     def test_command_context_pops_correctly(self):
@@ -441,7 +455,8 @@ class TestCommandContextWorksCorrectly(TestPhialBot):
         command_instance = phial.wrappers.Message('!test',
                                                   'channel_id',
                                                   'user',
-                                                  'timestamp')
+                                                  'timestamp',
+                                                  'team')
         self.bot._handle_message(command_instance)
 
         with self.assertRaises(RuntimeError) as context:
@@ -457,18 +472,21 @@ class TestParseSlackOutput(TestPhialBot):
                                 'text': '!test',
                                 'channel': 'channel_id',
                                 'user': 'user_id',
-                                'ts': 'timestamp'
+                                'ts': 'timestamp',
+                                'team': 'team'
                                }]
         command_message = self.bot._parse_slack_output(sample_slack_output)
         expected_command_message = phial.wrappers.Message('!test',
                                                           'channel_id',
                                                           'user_id',
-                                                          'timestamp')
+                                                          'timestamp',
+                                                          'team')
         self.assertEqual(command_message, expected_command_message)
 
     def test_returns_message_correctly_for_normal_message(self):
         sample_slack_output = [{'text': 'test', 'channel': 'channel_id',
-                                'user': 'user', 'ts': 'timestamp'}]
+                                'user': 'user', 'ts': 'timestamp',
+                                'team': 'team'}]
         command_message = self.bot._parse_slack_output(sample_slack_output)
         self.assertTrue(type(command_message) is phial.wrappers.Message)
 
@@ -483,7 +501,8 @@ class TestParseSlackOutput(TestPhialBot):
                                 'channel': 'channel_id',
                                 'user': 'user_id',
                                 'ts': 'timestamp',
-                                'bot_id': 'bot_id'
+                                'bot_id': 'bot_id',
+                                'team': 'team'
                               }]
         command_message = self.bot._parse_slack_output(sample_slack_output)
         self.assertEqual(command_message.bot_id, 'bot_id')
@@ -747,12 +766,14 @@ class TestExecuteResponse(TestPhialBot):
         message = phial.wrappers.Message(text="!test",
                                          channel="channel_id",
                                          user="user",
-                                         timestamp="timestamp")
+                                         timestamp="timestamp",
+                                         team="team")
         command_instance = phial.wrappers.Command(command_pattern="base",
                                                   channel="channel_id",
                                                   args={},
                                                   user="user",
-                                                  message=message)
+                                                  message=message,
+                                                  team="team")
         phial.globals._command_ctx_stack.push(command_instance)
         self.bot._execute_response("string")
         expected_response = Response(text='string', channel='channel_id')
@@ -872,7 +893,8 @@ class TestMiddleware(TestPhialBot):
         message = phial.wrappers.Message('!test',
                                          'channel_id',
                                          'user',
-                                         'timestamp')
+                                         'timestamp',
+                                         'team')
         self.bot._handle_message(message)
         middleware_test.assert_called_once_with(message)
         test.assert_not_called()
@@ -881,7 +903,8 @@ class TestMiddleware(TestPhialBot):
         message = phial.wrappers.Message('!test',
                                          'channel_id',
                                          'user',
-                                         'timestamp')
+                                         'timestamp',
+                                         'team')
         middleware_test = MagicMock(return_value=message)
         self.bot.add_middleware(middleware_test)
         test = MagicMock()
@@ -920,7 +943,8 @@ class TestHandleMessage(TestPhialBot):
                                          'channel_id',
                                          'user',
                                          'timestamp',
-                                         'bot_id')
+                                         'bot_id',
+                                         'team')
         test = MagicMock()
         self.bot.add_command('test', test)
         self.bot._handle_message(message)
@@ -951,13 +975,15 @@ class TestRun(TestPhialBot):
         command_message = phial.wrappers.Message('!test',
                                                  'channel_id',
                                                  'user',
-                                                 'timestamp')
+                                                 'timestamp',
+                                                 'team')
         self.bot._parse_slack_output = MagicMock(return_value=command_message)
         test_command = phial.wrappers.Command(re.compile('^test$'),
                                               'channel_id',
                                               {},
                                               'user_id',
-                                              command_message)
+                                              command_message,
+                                              'team')
         self.bot._create_command = MagicMock(return_value=test_command)
         self.bot._handle_command = MagicMock(return_value=None)
 
@@ -979,7 +1005,8 @@ class TestRun(TestPhialBot):
         test_command = phial.wrappers.Message('!test',
                                               'channel_id',
                                               'user_id',
-                                              'timestamp')
+                                              'timestamp',
+                                              'team')
         self.bot._parse_slack_output = MagicMock(return_value=test_command)
 
         expected_msg = 'Command !test not found'
@@ -1007,18 +1034,21 @@ class TestGlobalContext(unittest.TestCase):
         message = phial.wrappers.Message(text="!test",
                                          channel="channel_id",
                                          user="user",
-                                         timestamp="timestamp")
+                                         timestamp="timestamp",
+                                         team="team")
         command_instance = phial.wrappers.Command(command_pattern1,
                                                   'channel_id',
                                                   {},
                                                   'user',
-                                                  message)
+                                                  message,
+                                                  'team')
         bot.add_command('test2', second_command_function)
         second_command_instance = phial.wrappers.Command(command_pattern2,
                                                          'channel_id',
                                                          {},
                                                          'user',
-                                                         message)
+                                                         message,
+                                                         'team')
         bot._handle_command(command_instance)
         bot._handle_command(second_command_instance)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,6 +1,7 @@
 import unittest
-from unittest.mock import MagicMock
 from datetime import datetime, timedelta
+from freezegun import freeze_time
+from unittest.mock import MagicMock
 from phial.scheduler import Scheduler, Schedule, ScheduledJob
 
 
@@ -61,7 +62,19 @@ class TestSchedules(unittest.TestCase):
         expected_datetime = now + timedelta(seconds=2)
         assert next_run == expected_datetime
 
-    def test_at(self):
+    @freeze_time('2018-01-01 10:00:00')
+    def test_at_before_time(self):
+        schedule = Schedule().every().day().at(12, 00)
+        now = datetime.now()
+        next_run = schedule.get_next_run_time(now)
+        expected_datetime = (now).replace(hour=12,
+                                          minute=0,
+                                          second=0,
+                                          microsecond=0)
+        assert next_run == expected_datetime
+
+    @freeze_time('2018-01-01 13:00:00')
+    def test_at_after_time(self):
         schedule = Schedule().every().day().at(12, 00)
         now = datetime.now()
         next_run = schedule.get_next_run_time(now)


### PR DESCRIPTION
## Description
Add Team ID to Command and Message classes

## Motivation and Context
Makes potential future multi-team support easier

## Types of changes
Put an x in all boxes that apply
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Put an x in all boxes that apply
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have added/updated docstrings to the code I have touched.
- [x] All new and existing tests passed.
- [x] I have updated the Changelog to reflect my changes
- [x] Has the changes been tested against a real Slack instance?
