### PR TITLE
Allow commands to not have a docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Allow configuration to be partially updated ([@RealOrangeOne](https://github.com/RealOrangeOne) in [#81](https://github.com/sedders123/phial/pull/81))
 ### Fixed
  - Scheduled events using `every().day().at()`, now run on the day that the program is started on ([@runz0rd](https://github.com/runz0rd) in [#90](https://github.com/sedders123/phial/pull/90))
+ - Help command now allows commands to have no docstring, or override help text, specified.
 
 ## [0.6.0](https://github.com/sedders123/phial/releases/tag/0.6.0) - 2018-10-10
 ### Changed

--- a/phial/commands.py
+++ b/phial/commands.py
@@ -15,6 +15,9 @@ def help_command(bot: 'Phial') -> str:
         # deal with 'extending' functions to have extra attributes
         # GitHub Issue: https://github.com/python/mypy/issues/2087
         command_doc = bot.commands[command]._help  # type: ignore
+        if not command_doc:
+            # If no help text default to blank string
+            command_doc = ""
         commnad_help_text = parse_help_text(command_doc)
         command_name = bot.command_names[command]
         help_text += "*{0}* - {1}\n".format(command_name, commnad_help_text)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -17,6 +17,20 @@ class TestHelpCommand(unittest.TestCase):
 
         help_text = help_command(bot)
         self.assertEqual(help_text, expected_help_text)
+        
+     def test_help_command_allows_no_help_text(self):
+        bot = MagicMock()
+        bot.config = {}
+        command = MagicMock()
+
+        command._help = None
+        bot.commands = {"test_pattern": command}
+        bot.command_names = {"test_pattern": "test"}
+
+        expected_help_text = "*test* - \n"
+
+        help_text = help_command(bot)
+        self.assertEqual(help_text, expected_help_text)
 
     def test_help_command_multiple(self):
         bot = MagicMock()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -17,8 +17,8 @@ class TestHelpCommand(unittest.TestCase):
 
         help_text = help_command(bot)
         self.assertEqual(help_text, expected_help_text)
-        
-     def test_help_command_allows_no_help_text(self):
+
+    def test_help_command_allows_no_help_text(self):
         bot = MagicMock()
         bot.config = {}
         command = MagicMock()


### PR DESCRIPTION
## Description
Allow commands to not have a docstring

## Types of changes
Put an x in all boxes that apply
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Put an x in all boxes that apply
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the Changelog to reflect my changes
- [ ] Has the changes been tested against a real Slack instance?
