### PR TITLE
Add explicit dependency on pydocstyle

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ flake8-mutable==1.2.0
 freezegun==0.3.12
 isort==4.3.21
 mypy==0.711
+pydocstyle==3.0.0
 pytest==5.0.1
 pytest-cov==2.7.1
 rope==0.14.0


### PR DESCRIPTION
Temporary fix for https://gitlab.com/pycqa/flake8-docstrings/issues/36