### PR TITLE
Downgrade sphinx-autodoc-typehints to 1.8.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,6 +16,6 @@ pytest-cov==2.8.1
 rope==0.14.0
 setuptools==41.5.1
 sphinx==2.2.1
-sphinx-autodoc-typehints==1.9.0
+sphinx-autodoc-typehints==1.8.0
 twine==2.0.0
 wheel==0.33.6


### PR DESCRIPTION
This fixes issue where docs will not build