### PR TITLE
Downgrade sphinx-autodoc-typehints to 1.8.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,6 +16,6 @@ pytest-cov==2.8.1
 rope==0.14.0
 setuptools==41.5.1
 sphinx==2.2.1
-sphinx-autodoc-typehints==1.9.0
+sphinx-autodoc-typehints==1.8.0
 twine==2.0.0
 wheel==0.33.6


### PR DESCRIPTION
## Description
See agronholm/sphinx-autodoc-typehints#113 - the currently-installed version refuses to build HTML docs. To work around this, we should downgrade to 1.8.0. I've tested this version locally and it's all okay.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
Put an x in all boxes that apply
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] All new and existing tests passed.
